### PR TITLE
fix: Improved teammate colors fix method

### DIFF
--- a/MixScrims/MixScrims.csproj
+++ b/MixScrims/MixScrims.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="SwiftlyS2.CS2" Version="*" ExcludeAssets="runtime" PrivateAssets="all">
+    <PackageReference Include="SwiftlyS2.CS2" Version="*-*" ExcludeAssets="runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/MixScrims/src/Main.cs
+++ b/MixScrims/src/Main.cs
@@ -12,7 +12,7 @@ namespace MixScrims;
 
 [PluginMetadata(
     Id = "MixScrims",
-    Version = "1.5.1",
+    Version = "1.5.2",
     Name = "MixScrims",
     Author = "Shmitzas",
     Description = "A plugin for PUGS style matches, with in-game match management."

--- a/MixScrims/src/StateAgnostic/Events.cs
+++ b/MixScrims/src/StateAgnostic/Events.cs
@@ -567,6 +567,8 @@ partial class MixScrims
                 playingTPlayers.RemoveAll(p => p.PlayerID == player.PlayerID);
                 return HookResult.Continue;
             }
+
+            FixTeammateColors();
         }
 
         return HookResult.Stop;

--- a/MixScrims/src/States/MapChosen/Events.cs
+++ b/MixScrims/src/States/MapChosen/Events.cs
@@ -40,7 +40,8 @@ public partial class MixScrims
 
         if (matchState != MatchState.MapLoading)
         {
-            logger.LogWarning($"HandleMapChosenNewMapLoad: Ignored map start event because match state is {matchState}");
+            if (cfg.DetailedLogging)
+                logger.LogInformation($"HandleMapChosenNewMapLoad: Ignored map start event because match state is {matchState}");
             return;
         }
 

--- a/MixScrims/src/States/Match/Main.cs
+++ b/MixScrims/src/States/Match/Main.cs
@@ -85,6 +85,9 @@ public partial class MixScrims
                 playerColors[player.PlayerID] = freeColor.Value;
             }
         }
+
+        FixColorDuplicatesForTeam(Team.CT);
+        FixColorDuplicatesForTeam(Team.T);
     }
 
     /// <summary>
@@ -128,5 +131,43 @@ public partial class MixScrims
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Fixes color duplicates for a specific team by identifying players with the same color and reassigning free colors.
+    /// </summary>
+    private void FixColorDuplicatesForTeam(Team team)
+    {
+        var teamPlayers = GetPlayersInTeam(team)
+            .Where(p => playerColors.ContainsKey(p.PlayerID))
+            .ToList();
+
+        var colorGroups = teamPlayers
+            .GroupBy(p => playerColors[p.PlayerID])
+            .Where(g => g.Count() > 1)
+            .ToList();
+
+        foreach (var duplicateGroup in colorGroups)
+        {
+            var playersWithDuplicateColor = duplicateGroup.Skip(1).ToList();
+
+            foreach (var player in playersWithDuplicateColor)
+            {
+                var freeColor = GetFreePlayerColor(player);
+                if (freeColor != null)
+                {
+                    player.Controller.CompTeammateColor = freeColor.Value;
+                    player.Controller.CompTeammateColorUpdated();
+                    playerColors[player.PlayerID] = freeColor.Value;
+
+                    if (cfg.DetailedLogging)
+                        logger.LogInformation($"FixColorDuplicates: Reassigned player {player.Name} (ID: {player.PlayerID}) from color {duplicateGroup.Key} to {freeColor.Value} on {team}");
+                }
+                else
+                {
+                    logger.LogWarning($"FixColorDuplicates: Could not find free color for player {player.Name} (ID: {player.PlayerID}) on {team}");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bug fixes

- Fixed teammates colors not being assigned after they leave/join during the match
- Fixed rare cases where teammates colors would be duplicated across 2 or more teammates #41