### PR TITLE
feat: Mix will auto reset when server is empty

### DIFF
--- a/MixScrims/resources/translations/en.jsonc
+++ b/MixScrims/resources/translations/en.jsonc
@@ -128,5 +128,8 @@
   "command.votekick.passed.t": "[orange]{0} [default]was [red]kicked [default]by their team!",
   "command.votekick.failed": "Vote to kick [lime]{0} [red]failed[default].",
   "info.kick_reason.votekicked": "Voted out by your team",
-  "info.center.votekick.progress": "<span>Waiting for votes</span><br><span class=\"fontSize-sm\">[<span color=\"lime\">{0}</span>/<span color=\"lime\">{1}</span>] players voted</span>"
+  "info.center.votekick.progress": "<span>Waiting for votes</span><br><span class=\"fontSize-sm\">[<span color=\"lime\">{0}</span>/<span color=\"lime\">{1}</span>] players voted</span>",
+  "announcement.auto_reset.warning": "[red]Warning: [default]Only [gold]{0}[default]/[lime]{1} [default]players remain! Match will reset in [gold]{2}s [default]if players don't rejoin.",
+  "announcement.auto_reset.cancelled": "[lime]Auto-reset cancelled [default]- enough players are back!",
+  "announcement.auto_reset.triggered": "[red]Match reset! [default]Too few players remained for too long."
 }

--- a/MixScrims/resources/translations/pt-BR.jsonc
+++ b/MixScrims/resources/translations/pt-BR.jsonc
@@ -128,5 +128,8 @@
   "command.votekick.passed.t": "[orange]{0} [default]foi [red]expulso [default]pelo seu time!",
   "command.votekick.failed": "Votação para expulsar [lime]{0} [red]falhou[default].",
   "info.kick_reason.votekicked": "Expulso por votação do time",
-  "info.center.votekick.progress": "<span>Aguardando votos</span><br><span class=\"fontSize-sm\">[<span color=\"lime\">{0}</span>/<span color=\"lime\">{1}</span>] jogadores votaram</span>"
+  "info.center.votekick.progress": "<span>Aguardando votos</span><br><span class=\"fontSize-sm\">[<span color=\"lime\">{0}</span>/<span color=\"lime\">{1}</span>] jogadores votaram</span>",
+  "announcement.auto_reset.warning": "[red]Aviso: [default]Apenas [gold]{0}[default]/[lime]{1} [default]jogadores restam! A partida será reiniciada em [gold]{2}s [default]se os jogadores não voltarem.",
+  "announcement.auto_reset.cancelled": "[lime]Reinício automático cancelado [default]- jogadores suficientes voltaram!",
+  "announcement.auto_reset.triggered": "[red]Partida reiniciada! [default]Poucos jogadores permaneceram por muito tempo."
 }

--- a/MixScrims/src/Main.cs
+++ b/MixScrims/src/Main.cs
@@ -11,7 +11,7 @@ namespace MixScrims;
 
 [PluginMetadata(
     Id = "MixScrims",
-    Version = "1.6.1",
+    Version = "1.7.0",
     Name = "MixScrims",
     Author = "Shmitzas",
     Description = "A plugin for PUGS style matches, with in-game match management."

--- a/MixScrims/src/Shared/MainConfig.cs
+++ b/MixScrims/src/Shared/MainConfig.cs
@@ -41,6 +41,9 @@ public class MainConfig
     // Vote kick settings
     public VoteKickConfig VoteKick { get; set; } = new();
 
+    // Auto reset when players leave during match
+    public AutoResetOnLeaveConfig AutoResetOnLeave { get; set; } = new();
+
     // Player leave punishment settings
     public bool PunishPlayerLeaves { get; set; } = false;
     public LeavePunishment PlayerLeavePunishment { get; set; } = new();
@@ -114,5 +117,12 @@ public class VoteKickConfig
 {
     public bool Enabled { get; set; } = true;
     public int VoteKickTime { get; set; } = 30;
+}
+
+public class AutoResetOnLeaveConfig
+{
+    public bool Enabled { get; set; } = false;
+    public int MinimumPlayersRequired { get; set; } = 0;
+    public int GracePeriodSeconds { get; set; } = 10;
 }
 

--- a/MixScrims/src/StateAgnostic/Events.cs
+++ b/MixScrims/src/StateAgnostic/Events.cs
@@ -38,6 +38,14 @@ partial class MixScrims
         if (cfg.DetailedLogging)
             logger.LogInformation($"HandleClientPutInServer: Added player slot {playerSlot} to freshlyJoinedPlayers.");
 
+        if (resetMixOnFirstJoin)
+        {
+            logger.LogInformation("HandleClientPutInServer: resetMixOnFirstJoin flag is set, resetting match.");
+            resetMixOnFirstJoin = false;
+            ResetPluginState();
+            return;
+        }
+
         try
         {
             var player = Core.PlayerManager.GetPlayer(playerSlot);
@@ -361,6 +369,8 @@ partial class MixScrims
         {
             CheckReadyPlayersToStart();
         }
+
+        CheckAutoResetOnLeave();
     }
 
     /// <summary>
@@ -529,6 +539,7 @@ partial class MixScrims
                         logger.LogInformation($"HandlePlayerJoinTeam - Match: Player {player.Controller.PlayerName} joined CT team.");
                     playingCtPlayers.Add(player);
                     Core.Scheduler.NextTick(() => FixTeammateColors());
+                    CheckAutoResetOnLeave();
                     return HookResult.Continue;
                 }
 
@@ -537,6 +548,7 @@ partial class MixScrims
                     if (cfg.DetailedLogging)
                         logger.LogInformation($"HandlePlayerJoinTeam - Match: Player {player.Controller.PlayerName} re-joined CT team.");
                     Core.Scheduler.NextTick(() => FixTeammateColors());
+                    CheckAutoResetOnLeave();
                     return HookResult.Continue;
                 }
                 else
@@ -557,6 +569,7 @@ partial class MixScrims
                         logger.LogInformation($"HandlePlayerJoinTeam - Match: Player {player.Controller.PlayerName} joined T team.");
                     playingTPlayers.Add(player);
                     Core.Scheduler.NextTick(() => FixTeammateColors());
+                    CheckAutoResetOnLeave();
                     return HookResult.Continue;
                 }
 
@@ -565,6 +578,7 @@ partial class MixScrims
                     if (cfg.DetailedLogging)
                         logger.LogInformation($"HandlePlayerJoinTeam - Match: Player {player.Controller.PlayerName} re-joined T team.");
                     Core.Scheduler.NextTick(() => FixTeammateColors());
+                    CheckAutoResetOnLeave();
                     return HookResult.Continue;
                 }
                 else

--- a/MixScrims/src/StateAgnostic/Main.cs
+++ b/MixScrims/src/StateAgnostic/Main.cs
@@ -12,6 +12,7 @@ public sealed partial class MixScrims
     internal CancellationTokenSource? playerStatusTimerCenterHtml;
     internal CancellationTokenSource? commandRemindersTimer;
     internal CancellationTokenSource? captainsAnnouncementsTimer;
+    internal CancellationTokenSource? autoResetOnLeaveTimer;
 
     internal readonly List<IPlayer> readyPlayers = [];
     internal readonly List<int> freshlyJoinedPlayers = new();
@@ -22,6 +23,7 @@ public sealed partial class MixScrims
     internal bool preventNotPickedPlayersFromJoiningOngoingMatch = false;
     internal DateTime lastDiscordInviteSentAt = DateTime.MinValue;
     internal List<ulong> playersWaitingForPunishment = [];
+    internal bool resetMixOnFirstJoin = false;
 
     internal void StartAnnouncementTimers()
     {
@@ -503,6 +505,95 @@ public sealed partial class MixScrims
         }
 
         player.Kick(reason, ENetworkDisconnectionReason.NETWORK_DISCONNECT_DISCONNECT_BY_SERVER);
+    }
+
+    /// <summary>
+    /// Checks whether the active player count has dropped below the configured threshold during a match,
+    /// and starts or cancels the auto-reset grace period timer accordingly.
+    /// </summary>
+    internal void CheckAutoResetOnLeave()
+    {
+        if (!cfg.AutoResetOnLeave.Enabled)
+            return;
+
+        var matchState = mixScrimsService.GetCurrentMatchState();
+        if (matchState == MatchState.Warmup || matchState == MatchState.MapLoading)
+            return;
+
+        var currentPlayerCount = GetPlayingPlayers().Count(p => !IsBot(p));
+        var requiredPlayers = cfg.AutoResetOnLeave.MinimumPlayersRequired;
+
+        if (currentPlayerCount < requiredPlayers)
+        {
+            // If no human players remain, defer reset to when the next player joins.
+            // The server hibernates with 0 players so timers won't fire.
+            if (currentPlayerCount == 0)
+            {
+                logger.LogInformation("CheckAutoResetOnLeave: No human players remaining, deferring reset to next player join.");
+                autoResetOnLeaveTimer?.Cancel();
+                autoResetOnLeaveTimer = null;
+                resetMixOnFirstJoin = true;
+                return;
+            }
+
+            if (autoResetOnLeaveTimer != null)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogInformation("CheckAutoResetOnLeave: Timer already running, player count {Current}/{Required}", currentPlayerCount, requiredPlayers);
+                return;
+            }
+
+            logger.LogInformation("CheckAutoResetOnLeave: Player count {Current} below threshold {Required}, starting grace period of {Seconds}s", currentPlayerCount, requiredPlayers, cfg.AutoResetOnLeave.GracePeriodSeconds);
+
+            PrintMessageToAllPlayers(Core.Localizer["announcement.auto_reset.warning", currentPlayerCount, requiredPlayers, cfg.AutoResetOnLeave.GracePeriodSeconds]);
+
+            autoResetOnLeaveTimer = Core.Scheduler.DelayBySeconds(cfg.AutoResetOnLeave.GracePeriodSeconds, () =>
+            {
+                var currentState = mixScrimsService.GetCurrentMatchState();
+                if (currentState == MatchState.Warmup || currentState == MatchState.MapLoading)
+                {
+                    autoResetOnLeaveTimer = null;
+                    return;
+                }
+
+                var playersNow = GetPlayingPlayers().Count(p => !IsBot(p));
+                if (playersNow < requiredPlayers)
+                {
+                    logger.LogInformation("CheckAutoResetOnLeave: Grace period expired, player count {Current} still below {Required}. Resetting match.", playersNow, requiredPlayers);
+                    PrintMessageToAllPlayers(Core.Localizer["announcement.auto_reset.triggered"]);
+                    autoResetOnLeaveTimer = null;
+                    ResetPluginState();
+                }
+                else
+                {
+                    if (cfg.DetailedLogging)
+                        logger.LogInformation("CheckAutoResetOnLeave: Grace period expired but player count {Current} is now sufficient.", playersNow);
+                    autoResetOnLeaveTimer = null;
+                }
+            });
+            Core.Scheduler.StopOnMapChange(autoResetOnLeaveTimer);
+        }
+        else
+        {
+            CancelAutoResetOnLeaveTimer();
+        }
+    }
+
+    /// <summary>
+    /// Cancels the auto-reset grace period timer if it is currently running, and notifies players.
+    /// </summary>
+    internal void CancelAutoResetOnLeaveTimer(bool announce = true)
+    {
+        if (autoResetOnLeaveTimer != null)
+        {
+            if (cfg.DetailedLogging)
+                logger.LogInformation("CancelAutoResetOnLeaveTimer: Cancelling auto-reset timer, player count restored.");
+            autoResetOnLeaveTimer.Cancel();
+            autoResetOnLeaveTimer = null;
+
+            if (announce)
+                PrintMessageToAllPlayers(Core.Localizer["announcement.auto_reset.cancelled"]);
+        }
     }
 
     /// <summary>

--- a/MixScrims/src/States/KnifeRound/Main.cs
+++ b/MixScrims/src/States/KnifeRound/Main.cs
@@ -365,8 +365,8 @@ public partial class MixScrims
         {
             Core.Scheduler.NextWorldUpdate(() => 
             {
-                SetTeamName(Team.CT, captainCt?.Controller.PlayerName);
-                SetTeamName(Team.T, captainT?.Controller.PlayerName);
+                SetTeamName(Team.CT, IsPlayerValid(captainCt) ? captainCt!.Controller.PlayerName : null);
+                SetTeamName(Team.T, IsPlayerValid(captainT) ? captainT!.Controller.PlayerName : null);
 
                 isMovingPlayersToTeams = true;
 

--- a/MixScrims/src/States/Reset/Main.cs
+++ b/MixScrims/src/States/Reset/Main.cs
@@ -63,6 +63,8 @@ public partial class MixScrims
         playerColors.Clear();
         recentlyDisconnectedPlayers.Clear();
         freshlyJoinedPlayers.Clear();
+        resetMixOnFirstJoin = false;
+        CancelAutoResetOnLeaveTimer(announce: false);
         StopAllAnnouncmentTimers();
     }
 }


### PR DESCRIPTION
### New features
- **Broadened state coverage**: Auto-reset now triggers in all match states except Warmup and MapLoading
- **Excluded bots from player count**: Uses `!IsBot(p)` filter so CS2 bot replacements don't inflate the count
- **Deferred reset on empty server**: When all humans leave, sets `resetMixOnFirstJoin` flag instead of immediate reset (server hibernation prevents timers from firing)
- **Map change safety**: Skips auto-reset logic during `MapLoading` state to prevent false resets when players reconnect after map vote

### Bug fixes
- Fixed `ObjectDisposedException` in `SwitchStartingSides` when captain disconnects before the delayed team name update executes