### PR TITLE
fix: Improved team limiting, changing teams, logging

### DIFF
--- a/MixScrims/csgo_configs/knife_round.cfg
+++ b/MixScrims/csgo_configs/knife_round.cfg
@@ -24,7 +24,8 @@ mp_team_intro_time                                 0
 mp_warmup_end
 mp_friendlyfire                                    0
 mp_solid_teammates                                 1
-mp_limitteams                                      1
+mp_limitteams                                      0
+mp_autoteambalance                                 0
 mp_death_drop_gun                                  1
 sv_talk_enemy_dead                                 0
 sv_talk_enemy_living                               0

--- a/MixScrims/csgo_configs/match_start.cfg
+++ b/MixScrims/csgo_configs/match_start.cfg
@@ -7,6 +7,7 @@ sv_vote_issue_kick_allowed                         0
 sv_auto_full_alltalk_during_warmup_half_end        1
 mp_autokick                                        0
 mp_autoteambalance                                 0
+mp_limitteams                                      0
 mp_unpause_match
 
 cash_player_bomb_defused                           300

--- a/MixScrims/src/Main.cs
+++ b/MixScrims/src/Main.cs
@@ -11,7 +11,7 @@ namespace MixScrims;
 
 [PluginMetadata(
     Id = "MixScrims",
-    Version = "1.7.3",
+    Version = "1.7.4",
     Name = "MixScrims",
     Author = "Shmitzas",
     Description = "A plugin for PUGS style matches, with in-game match management."

--- a/MixScrims/src/Shared/MixScrimsService.cs
+++ b/MixScrims/src/Shared/MixScrimsService.cs
@@ -25,12 +25,27 @@ public class MixScrimsService : IMixScrims
 
     public void SetMatchState(MatchState state)
     {
+        var previous = _mixScrims.MatchState;
         _mixScrims.MatchState = state;
+        // State transitions are infrequent and high-signal. Log unconditionally (not gated
+        // by DetailedLogging) so issues like \"OT side switch dumps players to spec\" can be
+        // correlated with the surrounding state machine activity even on production servers.
+        if (previous != state)
+        {
+            _mixScrims.logger.LogInformation("SetMatchState: {Previous} -> {New} (playing CT:{Ct}/T:{T}, picked CT:{PCt}/T:{PT}, ready:{Ready})",
+                previous, state,
+                _mixScrims.playingCtPlayers.Count, _mixScrims.playingTPlayers.Count,
+                _mixScrims.pickedCtPlayers.Count, _mixScrims.pickedTPlayers.Count,
+                _mixScrims.readyPlayers.Count);
+        }
     }
 
     public void SetPluginState(PluginState state)
     {
+        var previous = _mixScrims.PluginState;
         _mixScrims.PluginState = state;
+        if (previous != state)
+            _mixScrims.logger.LogInformation("SetPluginState: {Previous} -> {New}", previous, state);
     }
 
     public void SetCounterTerroristsTeamName(string name)

--- a/MixScrims/src/StateAgnostic/Events.cs
+++ b/MixScrims/src/StateAgnostic/Events.cs
@@ -526,6 +526,22 @@ partial class MixScrims
         if (preventNotPickedPlayersFromJoiningOngoingMatch)
             return HookResult.Continue;
 
+        // While the plugin is performing a programmatic team move (side-swap at halftime
+        // or OT period boundaries, knife->match transition, stay/switch sides) we MUST NOT
+        // prune entries from the playing lists. The pre-handler bypasses with Continue
+        // without re-adding to the new list, so pruning here would leave the player
+        // untracked until ResyncPlayingListsFromEngine runs (1s after EventRoundStart).
+        // Any team event firing in that window would then treat them as untracked and
+        // force them to spec - the exact symptom of "OT side switch dumps half the
+        // players to spec". Resync will reconcile the lists with engine reality.
+        if (isMovingPlayersToTeams)
+        {
+            if (cfg.DetailedLogging)
+                logger.LogInformation("HandleEventPlayerTeamPost: skipping prune for {PlayerName} during programmatic move (committed team {Team}).",
+                    player.Controller.PlayerName, @event.Team);
+            return HookResult.Continue;
+        }
+
         // Committed team for this player. Use event value (Team=new) which is authoritative here.
         int committedTeam = @event.Team;
 
@@ -751,18 +767,27 @@ partial class MixScrims
                 if (cfg.DetailedLogging)
                     logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} joined Spectators.", player.Controller.PlayerName);
 
-                // Slot release on Spec move depends on config:
-                // - PreventNotPickedPlayersFromJoiningOngoingMatch = true: keep the slot reserved
-                //   for the player so no one else can take it (list identity preserved).
-                // - false: release the slot so other spectators can claim it. The player can still
-                //   rejoin via the normal capacity check as long as the team isn't full.
-                if (!preventNotPickedPlayersFromJoiningOngoingMatch)
+                // Voluntary move to Spectator releases the playing-list slot so any other
+                // currently-connected player can take it. Without this, the seat would stay
+                // occupied in the list and HandleActiveMatchJoin's capacity check would block
+                // every new joiner until the original player physically disconnects.
+                //
+                // Under PreventNotPickedPlayersFromJoiningOngoingMatch = true the player is
+                // additionally added to the side's reserved-slot set so they retain the right
+                // to come back to that side via the rejoin path in HandleActiveMatchJoin
+                // (hasReservation == true), as long as a free seat is available at the time.
+                bool wasInCt = playingCtPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
+                bool wasInT = playingTPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
+
+                if (preventNotPickedPlayersFromJoiningOngoingMatch)
                 {
-                    bool wasInCt = playingCtPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
-                    bool wasInT = playingTPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
-                    if (cfg.DetailedLogging && (wasInCt || wasInT))
-                        logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} moved to Spectator - released slot (CT:{Ct} T:{T}).", player.Controller.PlayerName, wasInCt, wasInT);
+                    if (wasInCt) reservedCtSlots.Add(player.SteamID);
+                    if (wasInT) reservedTSlots.Add(player.SteamID);
                 }
+
+                if (cfg.DetailedLogging && (wasInCt || wasInT))
+                    logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} moved to Spectator - released slot (CT:{Ct} T:{T}, reserved:{Reserved}).",
+                        player.Controller.PlayerName, wasInCt, wasInT, preventNotPickedPlayersFromJoiningOngoingMatch);
 
                 return HookResult.Continue;
             }

--- a/MixScrims/src/States/KnifeRound/Main.cs
+++ b/MixScrims/src/States/KnifeRound/Main.cs
@@ -113,7 +113,8 @@ public partial class MixScrims
         UnpauseMatch();
 
         Core.Engine.ExecuteCommand("exec mixscrims/knife_round.cfg");
-        
+        Core.Scheduler.NextTick(() => RelaxEngineTeamLimits("StartKnifeRound"));
+
         if (cfg.KickPlayersNotInMatch)
         {
             mixScrimsService.KickNotPlayingPlayers(Core.Localizer["info.kick_reason.not_picked"]);
@@ -467,8 +468,18 @@ public partial class MixScrims
                 continue;
             }
 
+            // ChangeTeam kills the player and recreates the pawn entity, which is expensive.
+            // Skip the call if the player is already on Spectator to avoid unnecessary entity churn.
+            int currentTeam = player.Controller?.TeamNum ?? -1;
+            if (currentTeam == (int)Team.Spectator)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogInformation("MovePlayersToDesignatedTeamsPreMatch: {PlayerName} already on SPEC, skipping.", player.Controller?.PlayerName ?? "<unknown>");
+                continue;
+            }
+
             if (cfg.DetailedLogging)
-                logger.LogInformation("Moving {PlayerName} to SPEC", player.Controller.PlayerName);
+                logger.LogInformation("Moving {PlayerName} to SPEC", player.Controller!.PlayerName);
             player.ChangeTeamAsync(Team.Spectator);
         }
 
@@ -478,8 +489,19 @@ public partial class MixScrims
             if (!playingCtPlayerIds.Contains(player.PlayerID))
                 continue;
 
+            // Skip if the player is already on CT — ChangeTeam kills/respawns the pawn,
+            // and doing this unnecessarily for every player on phase transitions causes
+            // ~1s server-frame stalls (combined with mp_restartgame in match_start.cfg).
+            int currentTeam = player.Controller?.TeamNum ?? -1;
+            if (currentTeam == (int)Team.CT)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogInformation("MovePlayersToDesignatedTeamsPreMatch: {PlayerName} already on CT, skipping.", player.Controller?.PlayerName ?? "<unknown>");
+                continue;
+            }
+
             if (cfg.DetailedLogging)
-                logger.LogInformation("Moving {PlayerName} to CT", player.Controller.PlayerName);
+                logger.LogInformation("Moving {PlayerName} to CT", player.Controller!.PlayerName);
             if (IsBot(player))
             {
                 player.SwitchTeamAsync(Team.CT);
@@ -497,8 +519,17 @@ public partial class MixScrims
             if (!playingTPlayerIds.Contains(player.PlayerID))
                 continue;
 
+            // Same reasoning as the CT loop above — avoid redundant pawn destroy/create.
+            int currentTeam = player.Controller?.TeamNum ?? -1;
+            if (currentTeam == (int)Team.T)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogInformation("MovePlayersToDesignatedTeamsPreMatch: {PlayerName} already on T, skipping.", player.Controller?.PlayerName ?? "<unknown>");
+                continue;
+            }
+
             if (cfg.DetailedLogging)
-                logger.LogInformation("Moving {PlayerName} to T", player.Controller.PlayerName);
+                logger.LogInformation("Moving {PlayerName} to T", player.Controller!.PlayerName);
             if (IsBot(player))
             {
                 player.SwitchTeamAsync(Team.T);

--- a/MixScrims/src/States/Match/Events.cs
+++ b/MixScrims/src/States/Match/Events.cs
@@ -2,6 +2,8 @@
 using SwiftlyS2.Shared.GameEventDefinitions;
 using SwiftlyS2.Shared.GameEvents;
 using SwiftlyS2.Shared.Misc;
+using SwiftlyS2.Shared.Players;
+using SwiftlyS2.Shared.SchemaDefinitions;
 using MixScrims.Contract;
 
 namespace MixScrims;
@@ -34,17 +36,30 @@ public partial class MixScrims
     }
 
     /// <summary>
-    /// Handles the halftime event during a match by preparing for team swap.
+    /// Pre-round hook that disables join validation while the engine performs any potential
+    /// side switch (regular halftime, OT halftime, or OT-period boundary). The bypass is
+    /// scoped to tracked players only (see HandlePlayerChangeTeam) so untracked joiners
+    /// remain validated.
     /// </summary>
-    [GameEventHandler (HookMode.Pre)]
-    public HookResult HandleMatchHalftime(EventRoundAnnounceLastRoundHalf @event)
+    [GameEventHandler(HookMode.Pre)]
+    public HookResult HandleMatchRoundPrestart(EventRoundPrestart @event)
     {
         var matchState = mixScrimsService.GetCurrentMatchState();
-        if (matchState == MatchState.Match)
+        if (matchState == MatchState.Match || matchState == MatchState.KnifeRound)
         {
+            // Engine-side defense: CS2's CCSGameRules uses NumSpawnable{T,CT} / MaxNum{T,CTs}
+            // together with mp_limitteams to kick "excess" players to spectator at side
+            // switches (regular halftime and EVERY overtime period boundary). Without this,
+            // when sides swap the engine briefly sees both teams piled on one side and
+            // dumps half the roster to spec - the plugin's isMovingPlayersToTeams bypass
+            // only prevents plugin-side rejections, not engine-side kicks. Re-applying
+            // every round-prestart guarantees the override survives any cvar reset.
+            RelaxEngineTeamLimits("RoundPrestart");
+
             if (cfg.DetailedLogging)
-                logger.LogInformation("Match halftime announced - disabling team validation");
-            
+                logger.LogInformation("HandleMatchRoundPrestart: state={State}, disabling team validation for potential side switch (CT list:{Ct} T list:{T})",
+                    matchState, playingCtPlayers.Count, playingTPlayers.Count);
+
             isMovingPlayersToTeams = true;
         }
 
@@ -52,36 +67,111 @@ public partial class MixScrims
     }
 
     /// <summary>
-    /// Handles the round start event, checking if halftime swap needs to be processed.
+    /// Post-round hook that, after the engine has finished assigning sides for the new
+    /// round, resyncs the plugin's CT/T playing lists from the engine's actual team
+    /// assignments and re-enables join validation. This is the source of truth for
+    /// every side-switch path (halftime, OT halftime, OT-period transitions, etc.)
+    /// and replaces the previous toggle-based halftime swap, which missed OT period
+    /// boundaries because <c>round_announce_last_round_half</c> does not fire there.
     /// </summary>
     [GameEventHandler(HookMode.Post)]
     public HookResult HandleRoundStart(EventRoundStart @event)
     {
         var matchState = mixScrimsService.GetCurrentMatchState();
-        if (matchState == MatchState.Match && isMovingPlayersToTeams)
+        if (matchState != MatchState.Match && matchState != MatchState.KnifeRound)
+            return HookResult.Continue;
+
+        // Re-apply the engine team limit override after round start too, in case the engine
+        // reset the values during its own SwitchTeamsAtRoundReset() pass.
+        RelaxEngineTeamLimits("RoundStart");
+
+        if (matchState != MatchState.Match)
+            return HookResult.Continue;
+
+        Core.Scheduler.DelayBySeconds(1f, () =>
         {
+            ResyncPlayingListsFromEngine();
+            isMovingPlayersToTeams = false;
             if (cfg.DetailedLogging)
-                logger.LogInformation("Round started after halftime - updating team lists");
-            
-            Core.Scheduler.DelayBySeconds(1f, () =>
-            {
-                var oldPlayingCtPlayers = playingCtPlayers.ToList();
-                var oldPlayingTPlayers = playingTPlayers.ToList();
-                playingCtPlayers = oldPlayingTPlayers;
-                playingTPlayers = oldPlayingCtPlayers;
-
-                if (cfg.DetailedLogging)
-                    logger.LogInformation("Halftime team lists updated - CT: {CT}, T: {T}", playingCtPlayers.Count, playingTPlayers.Count);
-
-                Core.Scheduler.DelayBySeconds(1f, () =>
-                {
-                    isMovingPlayersToTeams = false;
-                    if (cfg.DetailedLogging)
-                        logger.LogInformation("Halftime complete - team validation re-enabled");
-                });
-            });
-        }
+                logger.LogInformation("Round start resync complete - team validation re-enabled (CT:{CT} T:{T}, actual CT:{ActualCt} T:{ActualT})",
+                    playingCtPlayers.Count, playingTPlayers.Count,
+                    GetPlayersInTeam(Team.CT).Count, GetPlayersInTeam(Team.T).Count);
+        });
 
         return HookResult.Continue;
+    }
+
+    /// <summary>
+    /// Overrides the engine's per-team spawn/max-player counts to MaxClients to neutralize
+    /// CS2's built-in <c>mp_limitteams</c> / auto-balance behavior, which otherwise force-
+    /// moves players to Spectator at side switches (halftime + every OT halftime). Based
+    /// on the well-known TeamLimitFix pattern (OniquirAK/Fixes/TeamLimitFix.cs).
+    /// </summary>
+    /// <summary>
+    /// Overrides the engine's per-team spawn/max-player counts to MaxClients to neutralize
+    /// CS2's built-in <c>mp_limitteams</c> / auto-balance behavior, which otherwise force-
+    /// moves players to Spectator at side switches (halftime + every OT halftime). Based
+    /// on the well-known TeamLimitFix pattern (OniquirAK/Fixes/TeamLimitFix.cs).
+    /// </summary>
+    /// <remarks>
+    /// SAFETY: <c>CCSGameRules</c> is a native schema entity. Dereferencing a null or
+    /// invalid pointer, or writing to schema fields after the entity has been freed, will
+    /// segfault the CS2 server process (not a managed exception - the whole server dies).
+    /// Every access is therefore guarded by:
+    ///   1. A try/catch around the entire body (covers <c>InvalidOperationException</c>
+    ///      thrown by <c>Core.EntitySystem</c> when called too early, plus any native
+    ///      access violations the runtime can surface).
+    ///   2. An explicit null check on the returned reference.
+    ///   3. An <c>IsValid</c> check (point-in-time validity of the underlying entity).
+    ///   4. A sanity check that <c>MaxClients</c> is a positive value before writing.
+    /// Never call this method outside the main game thread (round/match event handlers
+    /// and <c>NextTick</c> callbacks are safe; arbitrary scheduler delays are too).
+    /// </remarks>
+    internal void RelaxEngineTeamLimits(string callSite)
+    {
+        try
+        {
+            CCSGameRules? gameRules = Core.EntitySystem.GetGameRules();
+            if (gameRules == null)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: GetGameRules() returned null - skipping override", callSite);
+                return;
+            }
+
+            if (!gameRules.IsValid)
+            {
+                if (cfg.DetailedLogging)
+                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: game rules entity is not valid - skipping override", callSite);
+                return;
+            }
+
+            int maxPlayers = Core.Engine.GlobalVars.MaxClients;
+            if (maxPlayers <= 0)
+            {
+                // Defensive: MaxClients should always be positive on a running server, but
+                // if it ever isn't, writing a zero/negative cap would make CS2 worse, not
+                // better. Bail rather than corrupt the schema.
+                if (cfg.DetailedLogging)
+                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: MaxClients={Max} is not positive - skipping override", callSite, maxPlayers);
+                return;
+            }
+
+            gameRules.NumSpawnableTerrorist = maxPlayers;
+            gameRules.MaxNumTerrorists = maxPlayers;
+            gameRules.NumSpawnableCT = maxPlayers;
+            gameRules.MaxNumCTs = maxPlayers;
+
+            if (cfg.DetailedLogging)
+                logger.LogInformation("RelaxEngineTeamLimits[{Site}]: NumSpawnable/MaxNum (T,CT) set to {Max}", callSite, maxPlayers);
+        }
+        catch (Exception ex)
+        {
+            // Catch-all on purpose: GetGameRules can throw InvalidOperationException when
+            // the entity system is not yet initialized, and a stale/freed schema pointer
+            // could theoretically surface as a managed exception. We must never let an
+            // exception from this defense-in-depth helper crash the plugin's event flow.
+            logger.LogError(ex, "RelaxEngineTeamLimits[{Site}]: failed to override engine team limits (exception swallowed)", callSite);
+        }
     }
 }

--- a/MixScrims/src/States/Match/Main.cs
+++ b/MixScrims/src/States/Match/Main.cs
@@ -28,6 +28,9 @@ public partial class MixScrims
         Core.Scheduler.NextTick(() =>
         {
             Core.Engine.ExecuteCommand("exec mixscrims/match_start.cfg");
+            // Override engine team limits immediately after match cvars settle, so the
+            // very first side switch (and every subsequent one) cannot dump players to spec.
+            RelaxEngineTeamLimits("StartMatch");
         });
 
         var mapName = Core.Engine.GlobalVars.MapName;
@@ -70,6 +73,93 @@ public partial class MixScrims
         {
             mixScrimsService.KickNotPlayingPlayers(Core.Localizer["info.kick_reason.not_picked"]);
         }
+    }
+
+    /// <summary>
+    /// Resynchronizes <see cref="playingCtPlayers"/> and <see cref="playingTPlayers"/>
+    /// with the engine's actual team assignments. Walks both lists, looks up each tracked
+    /// SteamID's current team, and moves them between lists when sides have been swapped
+    /// by the engine (regular halftime, OT halftime, OT-period transitions, surrender,
+    /// or any other engine-driven swap). Players currently in Spectator or disconnected
+    /// keep their existing assignment so reserved slots are preserved.
+    /// </summary>
+    internal void ResyncPlayingListsFromEngine()
+    {
+        // Snapshot to avoid mutating the lists we're iterating.
+        var ctSnapshot = playingCtPlayers.ToList();
+        var tSnapshot = playingTPlayers.ToList();
+
+        var newCt = new List<IPlayer>();
+        var newT = new List<IPlayer>();
+        int movedCtToT = 0;
+        int movedTToCt = 0;
+
+        void Place(IPlayer tracked, List<IPlayer> originList)
+        {
+            // Try to refresh the IPlayer reference (handles reconnects with new PlayerID/slot).
+            IPlayer? live = null;
+            try { live = GetPlayerBySteamId(tracked.SteamID); }
+            catch { live = null; }
+
+            var current = live ?? tracked;
+            int teamNum = -1;
+            if (current.IsValid && current.Controller != null)
+                teamNum = current.Controller.TeamNum;
+
+            if (teamNum == (int)Team.CT)
+                newCt.Add(current);
+            else if (teamNum == (int)Team.T)
+                newT.Add(current);
+            else
+            {
+                // Disconnected, in Spectator, or unassigned - keep on the original side
+                // so reserved-slot semantics are preserved.
+                if (originList == playingCtPlayers)
+                    newCt.Add(current);
+                else
+                    newT.Add(current);
+            }
+        }
+
+        foreach (var p in ctSnapshot)
+        {
+            int before = newCt.Count + newT.Count;
+            Place(p, playingCtPlayers);
+            // Track moves for logging
+            if (newT.Count + newCt.Count == before + 1
+                && newT.Count > 0
+                && newT[^1].SteamID == p.SteamID)
+                movedCtToT++;
+        }
+        foreach (var p in tSnapshot)
+        {
+            int before = newCt.Count + newT.Count;
+            Place(p, playingTPlayers);
+            if (newT.Count + newCt.Count == before + 1
+                && newCt.Count > 0
+                && newCt[^1].SteamID == p.SteamID)
+                movedTToCt++;
+        }
+
+        playingCtPlayers = newCt;
+        playingTPlayers = newT;
+
+        // Reservations are SteamID-based and must follow side switches too. When we detect any
+        // movement of tracked players between sides, swap the reservation sets so a reserved
+        // player who is currently in Spectator returns to the correct (post-swap) side.
+        if (movedCtToT > 0 || movedTToCt > 0)
+        {
+            var oldReservedCt = reservedCtSlots.ToList();
+            var oldReservedT = reservedTSlots.ToList();
+            reservedCtSlots.Clear();
+            reservedTSlots.Clear();
+            foreach (var s in oldReservedCt) reservedTSlots.Add(s);
+            foreach (var s in oldReservedT) reservedCtSlots.Add(s);
+        }
+
+        if (cfg.DetailedLogging && (movedCtToT > 0 || movedTToCt > 0))
+            logger.LogInformation("ResyncPlayingListsFromEngine: side swap detected - moved {CtToT} CT->T, {TToCt} T->CT (now CT:{CT} T:{T})",
+                movedCtToT, movedTToCt, playingCtPlayers.Count, playingTPlayers.Count);
     }
 
     /// <summary>


### PR DESCRIPTION
### Fix: Players moved to spectator during OT side switches

**Problem:** At halftime and every OT period boundary, the CS2 engine was force-moving roughly half the roster to Spectator.

**Root causes:**
- `mp_limitteams 1` was set during warmup/knife and never cleared for the match, so CCSGameRules kicked "excess" players on side swap.
- The post `player_team` handler pruned players from the playing lists during programmatic side swaps, leaving them untracked.

**Changes:**
- Added engine-side team-limit override (`NumSpawnable*` / `MaxNum*` → `MaxClients`) applied on round prestart, round start, match start, and knife start — based on the [OniquirAK `TeamLimitFix`](https://github.com/OniquirAK/Fixes/blob/main/TeamLimitFix.cs) pattern, with full null/`IsValid`/try-catch guards.
- Set `mp_limitteams 0` in `match_start.cfg` and `knife_round.cfg`.
- `HandleEventPlayerTeamPost` now skips list pruning while `isMovingPlayersToTeams` is active.
- Added unconditional state-transition logging in `MixScrimsService` plus additional `DetailedLogging` traces around round/team events for future diagnosis.