### PR TITLE
Fix/team handling and crash prevention

### DIFF
--- a/MixScrims/src/Main.cs
+++ b/MixScrims/src/Main.cs
@@ -82,9 +82,13 @@ public partial class MixScrims : BasePlugin
             timeoutVoteTimer?.Cancel();
             surrenderVoteTimer?.Cancel();
 
-            foreach (var cts in _punishmentTimers.Values)
+            foreach (var (steamId, cts) in _punishmentTimers)
             {
-                try { cts?.Cancel(); } catch { /* ignored */ }
+                try { cts?.Cancel(); }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "MixScrims.Unload: failed to cancel punishment timer for {SteamId}.", steamId);
+                }
             }
             _punishmentTimers.Clear();
         }
@@ -138,12 +142,18 @@ public partial class MixScrims : BasePlugin
         // but aliases registered manually via RegisterCommandAlias persist on hot reload
         // and will route into a dead plugin instance unless removed here.
         if (cfg?.Commands == null)
+        {
+            logger?.LogWarning("UnregisterCommands: cfg.Commands is null, skipping alias cleanup.");
             return;
+        }
 
         foreach (var (commandName, commandInfo) in cfg.Commands)
         {
             if (commandInfo?.Aliases == null)
+            {
+                logger?.LogWarning("UnregisterCommands: command {Command} has null aliases, skipping.", commandName);
                 continue;
+            }
 
             foreach (var alias in commandInfo.Aliases)
             {

--- a/MixScrims/src/Main.cs
+++ b/MixScrims/src/Main.cs
@@ -11,7 +11,7 @@ namespace MixScrims;
 
 [PluginMetadata(
     Id = "MixScrims",
-    Version = "1.7.4",
+    Version = "1.7.5",
     Name = "MixScrims",
     Author = "Shmitzas",
     Description = "A plugin for PUGS style matches, with in-game match management."
@@ -54,6 +54,45 @@ public partial class MixScrims : BasePlugin
 
     public override void Unload()
     {
+        try
+        {
+            // Unsubscribe explicit OnMapLoad handlers registered in RegisterListeners().
+            // [GameEventHandler]-attributed handlers are torn down by the framework on
+            // plugin unload, but these delegate-based subscriptions are not.
+            Core.Event.OnMapLoad -= WarmupHandleOnMapStart;
+            Core.Event.OnMapLoad -= AddPickedMapToPlayedMaps;
+            Core.Event.OnMapLoad -= HandleStateAgnosticMapLoad;
+            Core.Event.OnClientPutInServer -= HandleClientPutInServer;
+            Core.Event.OnClientDisconnected -= OnPlayerDisconnect;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "MixScrims.Unload: failed to unsubscribe lifecycle events.");
+        }
+
+        // Cancel every long-lived timer stored as an instance field so they cannot fire
+        // against a disposed plugin instance after a hot reload.
+        try
+        {
+            playerStatusTimer?.Cancel();
+            playerStatusTimerCenterHtml?.Cancel();
+            commandRemindersTimer?.Cancel();
+            captainsAnnouncementsTimer?.Cancel();
+            autoResetOnLeaveTimer?.Cancel();
+            timeoutVoteTimer?.Cancel();
+            surrenderVoteTimer?.Cancel();
+
+            foreach (var cts in _punishmentTimers.Values)
+            {
+                try { cts?.Cancel(); } catch { /* ignored */ }
+            }
+            _punishmentTimers.Clear();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "MixScrims.Unload: failed to cancel one or more timers.");
+        }
+
         UnregisterCommands();
         logger?.LogInformation("MixScrims unloading.");
     }
@@ -93,7 +132,32 @@ public partial class MixScrims : BasePlugin
     }
 
     internal void UnregisterCommands()
-    {}
+    {
+        // Unregister every alias we registered in RegisterCommands(). Primary commands
+        // are auto-unregistered by the framework via the [Command] attribute lifecycle,
+        // but aliases registered manually via RegisterCommandAlias persist on hot reload
+        // and will route into a dead plugin instance unless removed here.
+        if (cfg?.Commands == null)
+            return;
+
+        foreach (var (commandName, commandInfo) in cfg.Commands)
+        {
+            if (commandInfo?.Aliases == null)
+                continue;
+
+            foreach (var alias in commandInfo.Aliases)
+            {
+                try
+                {
+                    Core.Command.UnregisterCommand(alias);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "UnregisterCommands: failed to unregister alias {Alias} for {Command}.", alias, commandName);
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// Loads the configuration and initializes dependency injection services

--- a/MixScrims/src/Shared/Helpers.cs
+++ b/MixScrims/src/Shared/Helpers.cs
@@ -200,7 +200,10 @@ public sealed partial class MixScrims
         logger.LogInformation("Pausing match");
         Core.Scheduler.NextTick(() =>
         {
-            Core.Engine.ExecuteCommand("mp_pause_match");
+            if (Core.Engine is { } engine)
+                engine.ExecuteCommand("mp_pause_match");
+            else
+                logger.LogWarning("PauseMatch: Core.Engine unavailable; skipping mp_pause_match.");
         });
     }
 
@@ -212,7 +215,10 @@ public sealed partial class MixScrims
         logger.LogInformation("Unpausing match");
         Core.Scheduler.NextTick(() =>
         {
-            Core.Engine.ExecuteCommand("mp_unpause_match");
+            if (Core.Engine is { } engine)
+                engine.ExecuteCommand("mp_unpause_match");
+            else
+                logger.LogWarning("UnpauseMatch: Core.Engine unavailable; skipping mp_unpause_match.");
         });
     }
 

--- a/MixScrims/src/Shared/MixScrimsService.cs
+++ b/MixScrims/src/Shared/MixScrimsService.cs
@@ -121,6 +121,16 @@ public class MixScrimsService : IMixScrims
             return;
         }
 
+        // Debounce: refuse external map-change requests while another transition is already
+        // in flight. Stacking host_workshop_map / map commands across plugins is a known
+        // CS2 server crash trigger during the map-transition window.
+        var currentState = _mixScrims.mixScrimsService.GetCurrentMatchState();
+        if (currentState == MatchState.MapLoading || currentState == MatchState.MapChosen)
+        {
+            _mixScrims.logger.LogWarning("ChangeMap: ignoring external request to {Map}/{Workshop} - map change already in progress (state={State}).", mapName, workshopId, currentState);
+            return;
+        }
+
         if (!string.IsNullOrEmpty(workshopId))
         {
             var map = _mixScrims.GetMapByWorkshopId(workshopId);

--- a/MixScrims/src/StateAgnostic/Announcements.cs
+++ b/MixScrims/src/StateAgnostic/Announcements.cs
@@ -123,8 +123,7 @@ public partial class MixScrims
         }
         catch (Exception ex)
         {
-            if (cfg.DetailedLogging)
-                logger.LogError(ex, "SetPlayerReadyStatusInScoreboard: Failed to update clan tag for player {PlayerName}. Most likely player left the server while setting clan tag.", player?.Name ?? $"Slot: {player?.Slot}");
+            logger.LogWarning(ex, "SetPlayerReadyStatusInScoreboard: Failed to update clan tag for player {PlayerName}. Most likely player left the server while setting clan tag.", player?.Name ?? $"Slot: {player?.Slot}");
         }
     }
 
@@ -167,8 +166,7 @@ public partial class MixScrims
             }
             catch (Exception ex)
             {
-                if (cfg.DetailedLogging)
-                    logger.LogError(ex, "RemoveReadyClanTagsFromAllPlayers: Failed to remove clan tag for player {PlayerName}.", player?.Name ?? $"Slot: {player?.Slot}");
+                logger.LogWarning(ex, "RemoveReadyClanTagsFromAllPlayers: Failed to remove clan tag for player {PlayerName}.", player?.Name ?? $"Slot: {player?.Slot}");
             }
         }
     }

--- a/MixScrims/src/StateAgnostic/Events.cs
+++ b/MixScrims/src/StateAgnostic/Events.cs
@@ -110,16 +110,24 @@ partial class MixScrims
                 if (cfg.DetailedLogging)
                     logger.LogInformation("HandleClientPutInServer: Moving player slot {Slot} to Spectator team.", playerSlot);
                 
-                Core.Scheduler.DelayBySeconds(2, () =>
+                var specToken = Core.Scheduler.DelayBySeconds(2, () =>
                 {
-                    var delayedPlayer = Core.PlayerManager.GetPlayer(playerSlot);
-                    if (delayedPlayer != null && delayedPlayer.IsValid)
+                    try
                     {
-                        var currentState = mixScrimsService.GetCurrentMatchState();
-                        if (currentState == MatchState.Warmup || currentState == MatchState.MapVoting || currentState == MatchState.MapChosen)
-                            HandlePlayerChangeTeam(delayedPlayer, 0);
+                        var delayedPlayer = Core.PlayerManager.GetPlayer(playerSlot);
+                        if (delayedPlayer != null && delayedPlayer.IsValid)
+                        {
+                            var currentState = mixScrimsService.GetCurrentMatchState();
+                            if (currentState == MatchState.Warmup || currentState == MatchState.MapVoting || currentState == MatchState.MapChosen)
+                                HandlePlayerChangeTeam(delayedPlayer, 0);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "HandleClientPutInServer: deferred spectator move failed for slot {Slot}.", playerSlot);
                     }
                 });
+                Core.Scheduler.StopOnMapChange(specToken);
             }
         }
         catch (Exception ex)
@@ -233,26 +241,32 @@ partial class MixScrims
     private void ScheduleAutoJoinTeamSwitch(IPlayer player, Team targetTeam)
     {
         int playerSlot = player.Slot;
-        Core.Scheduler.DelayBySeconds(2, async () =>
+        ulong steamId = player.SteamID;
+        var token = Core.Scheduler.DelayBySeconds(2, async () =>
         {
             try
             {
-                if (player is null || !player.IsValid)
+                // Revalidate by slot + SteamID to ensure the captured reference still refers
+                // to the same physical player. After a map change the slot may belong to a
+                // different player whose IsValid would still return true.
+                var live = Core.PlayerManager.GetPlayer(playerSlot);
+                if (live is null || !live.IsValid || live.SteamID != steamId)
                 {
                     if (cfg.DetailedLogging)
-                        logger.LogInformation("ScheduleAutoJoinTeamSwitch: player (slot {Slot}) no longer valid, skipping switch to {Team}.", playerSlot, targetTeam);
+                        logger.LogInformation("ScheduleAutoJoinTeamSwitch: player (slot {Slot}, steamId {SteamId}) no longer valid, skipping switch to {Team}.", playerSlot, steamId, targetTeam);
                     return;
                 }
 
-                await player.SwitchTeamAsync(targetTeam);
+                await live.SwitchTeamAsync(targetTeam);
 
                 Core.Scheduler.NextTick(() =>
                 {
                     try
                     {
-                        if (player is null || !player.IsValid)
+                        var live2 = Core.PlayerManager.GetPlayer(playerSlot);
+                        if (live2 is null || !live2.IsValid || live2.SteamID != steamId)
                             return;
-                        RespawnPlayer(player);
+                        RespawnPlayer(live2);
                     }
                     catch (Exception ex)
                     {
@@ -265,6 +279,7 @@ partial class MixScrims
                 logger.LogError(ex, "ScheduleAutoJoinTeamSwitch: error switching team for player (slot {Slot}) to {Team}.", playerSlot, targetTeam);
             }
         });
+        Core.Scheduler.StopOnMapChange(token);
     }
 
     /// <summary>
@@ -307,7 +322,8 @@ partial class MixScrims
             return;
         recentlyDisconnectedPlayers.Add(player.Slot);
         var disconnectingPlayerSlot = player.Slot;
-        Core.Scheduler.DelayBySeconds(1, () => recentlyDisconnectedPlayers.Remove(disconnectingPlayerSlot));
+        var recentlyDisconnectedToken = Core.Scheduler.DelayBySeconds(1, () => recentlyDisconnectedPlayers.Remove(disconnectingPlayerSlot));
+        Core.Scheduler.StopOnMapChange(recentlyDisconnectedToken);
 
         // Cache player name for logging since Controller might become invalid during disconnect
         var playerName = IsPlayerValid(player) ? player.Controller.PlayerName : $"Player {player.PlayerID}";
@@ -335,41 +351,26 @@ partial class MixScrims
                                  matchState == MatchState.PickingStartingSide ||
                                  matchState == MatchState.Timeout;
 
-        // During active match states, slot reservation behavior depends on config
-        // If PreventNotPickedPlayersFromJoiningOngoingMatch is true: reserve slot (keep in list)
-        // If false: remove immediately to allow new players without exceeding limit
-        bool shouldReserveSlot = isActivMatchState && preventNotPickedPlayersFromJoiningOngoingMatch;
-        
-        if (playingCtPlayers.Any(p => p.PlayerID == player.PlayerID))
+        // Always free the slot on disconnect so any connected spectator can take it.
+        // The team-size cap is enforced strictly in HandleActiveMatchJoin using both the
+        // playing list and the live engine team count, so removing here cannot overflow.
+        // Also drop any stale reservation/forced-spectator marker for this SteamID.
+        _ = isActivMatchState; // retained for readability; behavior no longer branches on it here
+        reservedCtSlots.Remove(player.SteamID);
+        reservedTSlots.Remove(player.SteamID);
+
+        if (playingCtPlayers.Any(p => p.SteamID == player.SteamID))
         {
-            if (!shouldReserveSlot)
-            {
-                playingCtPlayers.RemoveAll(p => p.PlayerID == player.PlayerID);
-                if (cfg.DetailedLogging)
-                    logger.LogInformation("HandleDisconnectedPlayer: Removed {PlayerName} from playingCtPlayers.", playerName);
-            }
-            else
-            {
-                reservedCtSlots.Add(player.SteamID);
-                if (cfg.DetailedLogging)
-                    logger.LogInformation("HandleDisconnectedPlayer: {PlayerName} disconnected from CT - keeping slot reserved (SteamID {SteamId}).", playerName, player.SteamID);
-            }
+            playingCtPlayers.RemoveAll(p => p.SteamID == player.SteamID);
+            if (cfg.DetailedLogging)
+                logger.LogInformation("HandleDisconnectedPlayer: Removed {PlayerName} from playingCtPlayers.", playerName);
         }
 
-        if (playingTPlayers.Any(p => p.PlayerID == player.PlayerID))
+        if (playingTPlayers.Any(p => p.SteamID == player.SteamID))
         {
-            if (!shouldReserveSlot)
-            {
-                playingTPlayers.RemoveAll(p => p.PlayerID == player.PlayerID);
-                if (cfg.DetailedLogging)
-                    logger.LogInformation("HandleDisconnectedPlayer: Removed {PlayerName} from playingTPlayers.", playerName);
-            }
-            else
-            {
-                reservedTSlots.Add(player.SteamID);
-                if (cfg.DetailedLogging)
-                    logger.LogInformation("HandleDisconnectedPlayer: {PlayerName} disconnected from T - keeping slot reserved (SteamID {SteamId}).", playerName, player.SteamID);
-            }
+            playingTPlayers.RemoveAll(p => p.SteamID == player.SteamID);
+            if (cfg.DetailedLogging)
+                logger.LogInformation("HandleDisconnectedPlayer: Removed {PlayerName} from playingTPlayers.", playerName);
         }
 
         playerColors.Remove(player.PlayerID);
@@ -767,27 +768,19 @@ partial class MixScrims
                 if (cfg.DetailedLogging)
                     logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} joined Spectators.", player.Controller.PlayerName);
 
-                // Voluntary move to Spectator releases the playing-list slot so any other
-                // currently-connected player can take it. Without this, the seat would stay
-                // occupied in the list and HandleActiveMatchJoin's capacity check would block
-                // every new joiner until the original player physically disconnects.
-                //
-                // Under PreventNotPickedPlayersFromJoiningOngoingMatch = true the player is
-                // additionally added to the side's reserved-slot set so they retain the right
-                // to come back to that side via the rejoin path in HandleActiveMatchJoin
-                // (hasReservation == true), as long as a free seat is available at the time.
+                // Voluntary move to Spectator fully releases the slot so any other connected
+                // player can take it. No reservation is held: returning to a team uses the
+                // normal capacity-checked join path. Any stale reservation/force-spec marker
+                // for this SteamID is also cleared so it cannot block their own rejoin later.
                 bool wasInCt = playingCtPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
                 bool wasInT = playingTPlayers.RemoveAll(p => p.SteamID == player.SteamID) > 0;
-
-                if (preventNotPickedPlayersFromJoiningOngoingMatch)
-                {
-                    if (wasInCt) reservedCtSlots.Add(player.SteamID);
-                    if (wasInT) reservedTSlots.Add(player.SteamID);
-                }
+                reservedCtSlots.Remove(player.SteamID);
+                reservedTSlots.Remove(player.SteamID);
+                forcedToSpectator.Remove(player.SteamID);
 
                 if (cfg.DetailedLogging && (wasInCt || wasInT))
-                    logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} moved to Spectator - released slot (CT:{Ct} T:{T}, reserved:{Reserved}).",
-                        player.Controller.PlayerName, wasInCt, wasInT, preventNotPickedPlayersFromJoiningOngoingMatch);
+                    logger.LogInformation("HandlePlayerJoinTeam - Match: {PlayerName} moved to Spectator - released slot (CT:{Ct} T:{T}).",
+                        player.Controller.PlayerName, wasInCt, wasInT);
 
                 return HookResult.Continue;
             }
@@ -858,11 +851,13 @@ partial class MixScrims
             return HookResult.Stop;
         }
 
-        // Use the larger of list-count and actual engine-team count. This closes races where
-        // engine-side placements during the isMovingPlayersToTeams window inflated the actual
-        // team count above the tracked list count.
-        int effectiveCount = Math.Max(listCount, actualCount);
-        if (effectiveCount < maxTeamSize)
+        // Strict capacity: both the tracked list AND the live engine team must have a free
+        // seat. listCount can lag behind reality (e.g. a CT->Spec event whose Post-prune has
+        // not committed yet) and actualCount can lag too (engine commit happens after the
+        // Pre hook). Requiring BOTH to be under the cap prevents two concurrent joiners from
+        // overflowing the team through the gap and matches the user-visible expectation
+        // that the team count never exceeds MinimumReadyPlayers/2.
+        if (listCount < maxTeamSize && actualCount < maxTeamSize)
         {
             if (cfg.DetailedLogging)
                 logger.LogInformation("HandleActiveMatchJoin - {Team}: {PlayerName} joined (list:{List}, actual:{Actual}, max:{Max}).",

--- a/MixScrims/src/StateAgnostic/Events.cs
+++ b/MixScrims/src/StateAgnostic/Events.cs
@@ -577,8 +577,7 @@ partial class MixScrims
 
         if (player == null)
         {
-            if (cfg.DetailedLogging)
-                logger.LogWarning("HandlePlayerChangeTeam: player is null");
+            logger.LogWarning("HandlePlayerChangeTeam: player is null, stopping jointeam handling.");
             return HookResult.Stop;
         }
 
@@ -591,8 +590,7 @@ partial class MixScrims
 
         if (!player.IsValid)
         {
-            if (cfg.DetailedLogging)
-                logger.LogWarning("HandlePlayerChangeTeam: player is not valid");
+            logger.LogWarning("HandlePlayerChangeTeam: player {Slot} is not valid, stopping jointeam handling.", player.Slot);
             return HookResult.Stop;
         }
 

--- a/MixScrims/src/StateAgnostic/Main.cs
+++ b/MixScrims/src/StateAgnostic/Main.cs
@@ -148,7 +148,8 @@ public sealed partial class MixScrims
                     }
                     finally
                     {
-                        Core.Scheduler.DelayBySeconds(1, () => isMovingPlayersToTeams = false);
+                        var resetFlagToken = Core.Scheduler.DelayBySeconds(1, () => isMovingPlayersToTeams = false);
+                        Core.Scheduler.StopOnMapChange(resetFlagToken);
                     }
 
                     if (!informed)
@@ -354,15 +355,24 @@ public sealed partial class MixScrims
     /// </summary>
     internal void LoadMap(MapDetails map)
     {
+        // Guard against null engine: this is the actual map-switch command issuer and runs
+        // during the most dangerous window of a transition. A second concurrent caller can
+        // have already torn the engine down between scheduling and firing.
+        if (Core.Engine is not { } engine)
+        {
+            logger.LogWarning("LoadMap: Core.Engine unavailable; skipping map switch to {Map}.", map.MapName);
+            return;
+        }
+
 		if (cfg.DetailedLogging)
 			logger.LogInformation("LoadMap: Executing map change to {Map}", map.MapName);
         if (map.IsWorkshopMap && !string.IsNullOrWhiteSpace(map.WorkshopId))
         {
-            Core.Engine.ExecuteCommand($"host_workshop_map {map.WorkshopId}");
+            engine.ExecuteCommand($"host_workshop_map {map.WorkshopId}");
         }
         else
         {
-            Core.Engine.ExecuteCommand($"map {map.MapName}");
+            engine.ExecuteCommand($"map {map.MapName}");
         }
     }
 
@@ -418,13 +428,15 @@ public sealed partial class MixScrims
         {
             Core.Scheduler.NextTick(() =>
             {
+                if (Core.Engine is not { } engine)
+                    return;
                 if (teamName is null)
                 {
-                    Core.Engine.ExecuteCommand("mp_teamname_1 COUNTER-TERRORISTS");
+                    engine.ExecuteCommand("mp_teamname_1 COUNTER-TERRORISTS");
                 }
                 else
                 {
-                    Core.Engine.ExecuteCommand($"mp_teamname_1 team_{teamName}");
+                    engine.ExecuteCommand($"mp_teamname_1 team_{teamName}");
                 }
             });
         }
@@ -432,13 +444,15 @@ public sealed partial class MixScrims
         {
             Core.Scheduler.NextTick(() =>
             {
+                if (Core.Engine is not { } engine)
+                    return;
                 if (teamName is null)
                 {
-                    Core.Engine.ExecuteCommand("mp_teamname_2 TERRORISTS");
+                    engine.ExecuteCommand("mp_teamname_2 TERRORISTS");
                 }
                 else
                 {
-                    Core.Engine.ExecuteCommand($"mp_teamname_2 team_{teamName}");
+                    engine.ExecuteCommand($"mp_teamname_2 team_{teamName}");
                 }
             });
         }

--- a/MixScrims/src/StateAgnostic/Main.cs
+++ b/MixScrims/src/StateAgnostic/Main.cs
@@ -429,7 +429,10 @@ public sealed partial class MixScrims
             Core.Scheduler.NextTick(() =>
             {
                 if (Core.Engine is not { } engine)
+                {
+                    logger.LogWarning("SetTeamName: Core.Engine unavailable; skipping CT team name update.");
                     return;
+                }
                 if (teamName is null)
                 {
                     engine.ExecuteCommand("mp_teamname_1 COUNTER-TERRORISTS");
@@ -445,7 +448,10 @@ public sealed partial class MixScrims
             Core.Scheduler.NextTick(() =>
             {
                 if (Core.Engine is not { } engine)
+                {
+                    logger.LogWarning("SetTeamName: Core.Engine unavailable; skipping T team name update.");
                     return;
+                }
                 if (teamName is null)
                 {
                     engine.ExecuteCommand("mp_teamname_2 TERRORISTS");
@@ -651,7 +657,10 @@ public sealed partial class MixScrims
         }
         Core.Scheduler.NextTick(() =>
         {
-            Core.Engine.ExecuteCommand(banCommand);
+            if (Core.Engine is { } engine)
+                engine.ExecuteCommand(banCommand);
+            else
+                logger.LogWarning("ExecutePunishmentCommand: Core.Engine unavailable; skipping ban command for {SteamId}.", steamId);
         });
         playersWaitingForPunishment.Remove(steamId);
         _punishmentTimers.Remove(steamId);

--- a/MixScrims/src/States/KnifeRound/Main.cs
+++ b/MixScrims/src/States/KnifeRound/Main.cs
@@ -112,7 +112,10 @@ public partial class MixScrims
 
         UnpauseMatch();
 
-        Core.Engine.ExecuteCommand("exec mixscrims/knife_round.cfg");
+        if (Core.Engine is { } knifeEngine)
+            knifeEngine.ExecuteCommand("exec mixscrims/knife_round.cfg");
+        else
+            logger.LogWarning("StartKnifeRound: Core.Engine unavailable; skipping knife_round.cfg.");
         Core.Scheduler.NextTick(() => RelaxEngineTeamLimits("StartKnifeRound"));
 
         if (cfg.KickPlayersNotInMatch)
@@ -384,8 +387,7 @@ public partial class MixScrims
                             try { player.ChangeTeamAsync(Team.T); }
                             catch (Exception ex)
                             {
-                                if (cfg.DetailedLogging)
-                                    logger.LogWarning(ex, "SwitchStartingSides: Error changing T player team.");
+                                logger.LogWarning(ex, "SwitchStartingSides: Error changing team to T for {PlayerName}.", player.Controller.PlayerName);
                             }
                         }
                     }
@@ -409,8 +411,7 @@ public partial class MixScrims
                             try { player.ChangeTeamAsync(Team.CT); }
                             catch (Exception ex)
                             {
-                                if (cfg.DetailedLogging)
-                                    logger.LogWarning(ex, "SwitchStartingSides: Error changing CT player team.");
+                                logger.LogWarning(ex, "SwitchStartingSides: Error changing team to CT for {PlayerName}.", player.Controller.PlayerName);
                             }
                         }
                     }

--- a/MixScrims/src/States/KnifeRound/Main.cs
+++ b/MixScrims/src/States/KnifeRound/Main.cs
@@ -362,7 +362,7 @@ public partial class MixScrims
         captainCt = oldTCaptain;
         captainT = oldCtCaptain;
 
-        Core.Scheduler.DelayBySeconds(0.2f, () =>
+        var switchSidesToken = Core.Scheduler.DelayBySeconds(0.2f, () =>
         {
             Core.Scheduler.NextWorldUpdate(() => 
             {
@@ -426,6 +426,7 @@ public partial class MixScrims
 
             StartMatch();
         });
+        Core.Scheduler.StopOnMapChange(switchSidesToken);
     }
 
     /// <summary>

--- a/MixScrims/src/States/Match/Events.cs
+++ b/MixScrims/src/States/Match/Events.cs
@@ -40,8 +40,7 @@ public partial class MixScrims
                 // a value type so only the engine reference is null-checked here.
                 if (Core.Engine is not { } engine)
                 {
-                    if (cfg.DetailedLogging)
-                        logger.LogWarning("HandleMatchEnd: Core.Engine unavailable, skipping post-match LoadMap.");
+                    logger.LogWarning("HandleMatchEnd: Core.Engine unavailable, skipping post-match LoadMap.");
                     return;
                 }
 
@@ -172,15 +171,13 @@ public partial class MixScrims
             CCSGameRules? gameRules = Core.EntitySystem.GetGameRules();
             if (gameRules == null)
             {
-                if (cfg.DetailedLogging)
-                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: GetGameRules() returned null - skipping override", callSite);
+                logger.LogWarning("RelaxEngineTeamLimits[{Site}]: GetGameRules() returned null - skipping override", callSite);
                 return;
             }
 
             if (!gameRules.IsValid)
             {
-                if (cfg.DetailedLogging)
-                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: game rules entity is not valid - skipping override", callSite);
+                logger.LogWarning("RelaxEngineTeamLimits[{Site}]: game rules entity is not valid - skipping override", callSite);
                 return;
             }
 
@@ -190,8 +187,7 @@ public partial class MixScrims
                 // Defensive: MaxClients should always be positive on a running server, but
                 // if it ever isn't, writing a zero/negative cap would make CS2 worse, not
                 // better. Bail rather than corrupt the schema.
-                if (cfg.DetailedLogging)
-                    logger.LogWarning("RelaxEngineTeamLimits[{Site}]: MaxClients={Max} is not positive - skipping override", callSite, maxPlayers);
+                logger.LogWarning("RelaxEngineTeamLimits[{Site}]: MaxClients={Max} is not positive - skipping override", callSite, maxPlayers);
                 return;
             }
 

--- a/MixScrims/src/States/Match/Events.cs
+++ b/MixScrims/src/States/Match/Events.cs
@@ -17,21 +17,51 @@ public partial class MixScrims
     public HookResult HandleMatchEnd(EventCsWinPanelMatch @event)
     {
         var matchState = mixScrimsService.GetCurrentMatchState();
-        if (matchState == MatchState.Match)
+        if (matchState != MatchState.Match)
+            return HookResult.Continue;
+
+        var token = Core.Scheduler.DelayBySeconds(10, () =>
         {
-            Core.Scheduler.DelayBySeconds(10, () =>
+            try
             {
+                // Bail if another component has already initiated a map change in the
+                // meantime - stacking host_workshop_map / map commands across plugins is
+                // the classic CS2 map-transition crash window.
+                var stateNow = mixScrimsService.GetCurrentMatchState();
+                if (stateNow == MatchState.MapLoading || stateNow == MatchState.MapChosen)
+                {
+                    if (cfg.DetailedLogging)
+                        logger.LogInformation("HandleMatchEnd: map change already in progress ({State}), skipping post-match LoadMap.", stateNow);
+                    return;
+                }
+
+                // Engine null-guard: a concurrent transition (MapChooser, end-of-map cycle)
+                // may have begun tearing the world down within the 10s window. GlobalVars is
+                // a value type so only the engine reference is null-checked here.
+                if (Core.Engine is not { } engine)
+                {
+                    if (cfg.DetailedLogging)
+                        logger.LogWarning("HandleMatchEnd: Core.Engine unavailable, skipping post-match LoadMap.");
+                    return;
+                }
+
                 if (cfg.DetailedLogging)
                     logger.LogInformation("Match ended, transitioning to Fresh match state.");
                 ResetPluginState();
-                MapDetails map = new();
+                var mapNameStr = engine.GlobalVars.MapName.ToString() ?? string.Empty;
+                var map = new MapDetails
                 {
-                    map.MapName = Core.Engine.GlobalVars.MapName;
-                    map.DisplayName = Core.Engine.GlobalVars.MapName;
+                    MapName = mapNameStr,
+                    DisplayName = mapNameStr,
                 };
                 LoadMap(map);
-            });
-        }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "HandleMatchEnd: delayed post-match callback failed.");
+            }
+        });
+        Core.Scheduler.StopOnMapChange(token);
         return HookResult.Continue;
     }
 
@@ -88,15 +118,23 @@ public partial class MixScrims
         if (matchState != MatchState.Match)
             return HookResult.Continue;
 
-        Core.Scheduler.DelayBySeconds(1f, () =>
+        var resyncToken = Core.Scheduler.DelayBySeconds(1f, () =>
         {
-            ResyncPlayingListsFromEngine();
-            isMovingPlayersToTeams = false;
-            if (cfg.DetailedLogging)
-                logger.LogInformation("Round start resync complete - team validation re-enabled (CT:{CT} T:{T}, actual CT:{ActualCt} T:{ActualT})",
-                    playingCtPlayers.Count, playingTPlayers.Count,
-                    GetPlayersInTeam(Team.CT).Count, GetPlayersInTeam(Team.T).Count);
+            try
+            {
+                ResyncPlayingListsFromEngine();
+                isMovingPlayersToTeams = false;
+                if (cfg.DetailedLogging)
+                    logger.LogInformation("Round start resync complete - team validation re-enabled (CT:{CT} T:{T}, actual CT:{ActualCt} T:{ActualT})",
+                        playingCtPlayers.Count, playingTPlayers.Count,
+                        GetPlayersInTeam(Team.CT).Count, GetPlayersInTeam(Team.T).Count);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "HandleRoundStart: deferred resync failed.");
+            }
         });
+        Core.Scheduler.StopOnMapChange(resyncToken);
 
         return HookResult.Continue;
     }

--- a/MixScrims/src/States/Match/Main.cs
+++ b/MixScrims/src/States/Match/Main.cs
@@ -27,13 +27,19 @@ public partial class MixScrims
         UnpauseMatch();
         Core.Scheduler.NextTick(() =>
         {
-            Core.Engine.ExecuteCommand("exec mixscrims/match_start.cfg");
+            if (Core.Engine is { } engine)
+                engine.ExecuteCommand("exec mixscrims/match_start.cfg");
             // Override engine team limits immediately after match cvars settle, so the
             // very first side switch (and every subsequent one) cannot dump players to spec.
             RelaxEngineTeamLimits("StartMatch");
         });
 
-        var mapName = Core.Engine.GlobalVars.MapName;
+        if (Core.Engine is not { } matchEngine)
+        {
+            logger.LogError("StartMatch: Core.Engine unavailable");
+            return;
+        }
+        var mapName = matchEngine.GlobalVars.MapName.ToString();
         if (string.IsNullOrEmpty(mapName))
         {
             logger.LogError("StartMatch: mapName is null or empty");
@@ -85,26 +91,54 @@ public partial class MixScrims
     /// </summary>
     internal void ResyncPlayingListsFromEngine()
     {
-        // Snapshot to avoid mutating the lists we're iterating.
-        var ctSnapshot = playingCtPlayers.ToList();
-        var tSnapshot = playingTPlayers.ToList();
+        // Snapshot SteamIDs (value-type) up front rather than IPlayer references. The
+        // tracked IPlayer objects may have been disposed by SwiftlyS2 between the time
+        // they were added to the list and this resync (e.g. a player disconnected after
+        // the round-prestart). Accessing .SteamID on a disposed Player throws
+        // ObjectDisposedException, which previously killed the entire resync and left the
+        // playing lists desynced from the engine.
+        static ulong SafeSteamId(IPlayer p)
+        {
+            try { return p.SteamID; }
+            catch { return 0UL; }
+        }
+
+        var ctSnapshot = playingCtPlayers
+            .Select(p => (player: p, steamId: SafeSteamId(p)))
+            .ToList();
+        var tSnapshot = playingTPlayers
+            .Select(p => (player: p, steamId: SafeSteamId(p)))
+            .ToList();
 
         var newCt = new List<IPlayer>();
         var newT = new List<IPlayer>();
         int movedCtToT = 0;
         int movedTToCt = 0;
 
-        void Place(IPlayer tracked, List<IPlayer> originList)
+        void Place(IPlayer tracked, ulong steamId, List<IPlayer> originList)
         {
+            // Drop entries whose SteamID could not be read (disposed object). These
+            // belong to disconnected players that HandleDisconnectedPlayer will/has
+            // already pruned; carrying them forward only re-introduces disposed refs.
+            if (steamId == 0UL)
+                return;
+
             // Try to refresh the IPlayer reference (handles reconnects with new PlayerID/slot).
             IPlayer? live = null;
-            try { live = GetPlayerBySteamId(tracked.SteamID); }
+            try { live = GetPlayerBySteamId(steamId); }
             catch { live = null; }
 
             var current = live ?? tracked;
             int teamNum = -1;
-            if (current.IsValid && current.Controller != null)
-                teamNum = current.Controller.TeamNum;
+            try
+            {
+                if (current.IsValid && current.Controller != null)
+                    teamNum = current.Controller.TeamNum;
+            }
+            catch
+            {
+                teamNum = -1;
+            }
 
             if (teamNum == (int)Team.CT)
                 newCt.Add(current);
@@ -112,8 +146,9 @@ public partial class MixScrims
                 newT.Add(current);
             else
             {
-                // Disconnected, in Spectator, or unassigned - keep on the original side
-                // so reserved-slot semantics are preserved.
+                // Currently in Spectator or unassigned - keep on the original side so
+                // a player who briefly went to spec is still tracked on their team.
+                // Disposed/disconnected players were filtered out above.
                 if (originList == playingCtPlayers)
                     newCt.Add(current);
                 else
@@ -121,23 +156,23 @@ public partial class MixScrims
             }
         }
 
-        foreach (var p in ctSnapshot)
+        foreach (var (player, steamId) in ctSnapshot)
         {
             int before = newCt.Count + newT.Count;
-            Place(p, playingCtPlayers);
+            Place(player, steamId, playingCtPlayers);
             // Track moves for logging
             if (newT.Count + newCt.Count == before + 1
                 && newT.Count > 0
-                && newT[^1].SteamID == p.SteamID)
+                && SafeSteamId(newT[^1]) == steamId)
                 movedCtToT++;
         }
-        foreach (var p in tSnapshot)
+        foreach (var (player, steamId) in tSnapshot)
         {
             int before = newCt.Count + newT.Count;
-            Place(p, playingTPlayers);
+            Place(player, steamId, playingTPlayers);
             if (newT.Count + newCt.Count == before + 1
                 && newCt.Count > 0
-                && newCt[^1].SteamID == p.SteamID)
+                && SafeSteamId(newCt[^1]) == steamId)
                 movedTToCt++;
         }
 

--- a/MixScrims/src/States/Match/Main.cs
+++ b/MixScrims/src/States/Match/Main.cs
@@ -29,6 +29,8 @@ public partial class MixScrims
         {
             if (Core.Engine is { } engine)
                 engine.ExecuteCommand("exec mixscrims/match_start.cfg");
+            else
+                logger.LogWarning("StartMatch: Core.Engine unavailable; skipping match_start.cfg.");
             // Override engine team limits immediately after match cvars settle, so the
             // very first side switch (and every subsequent one) cannot dump players to spec.
             RelaxEngineTeamLimits("StartMatch");
@@ -97,10 +99,14 @@ public partial class MixScrims
         // the round-prestart). Accessing .SteamID on a disposed Player throws
         // ObjectDisposedException, which previously killed the entire resync and left the
         // playing lists desynced from the engine.
-        static ulong SafeSteamId(IPlayer p)
+        ulong SafeSteamId(IPlayer p)
         {
             try { return p.SteamID; }
-            catch { return 0UL; }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "ResyncPlayingListsFromEngine: failed reading SteamID from tracked player reference (likely disposed).");
+                return 0UL;
+            }
         }
 
         var ctSnapshot = playingCtPlayers
@@ -121,12 +127,19 @@ public partial class MixScrims
             // belong to disconnected players that HandleDisconnectedPlayer will/has
             // already pruned; carrying them forward only re-introduces disposed refs.
             if (steamId == 0UL)
+            {
+                logger.LogWarning("ResyncPlayingListsFromEngine: dropping tracked player due to unreadable SteamID (disposed reference).");
                 return;
+            }
 
             // Try to refresh the IPlayer reference (handles reconnects with new PlayerID/slot).
             IPlayer? live = null;
             try { live = GetPlayerBySteamId(steamId); }
-            catch { live = null; }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "ResyncPlayingListsFromEngine: exception while refreshing player by SteamID {SteamId}.", steamId);
+                live = null;
+            }
 
             var current = live ?? tracked;
             int teamNum = -1;
@@ -135,8 +148,9 @@ public partial class MixScrims
                 if (current.IsValid && current.Controller != null)
                     teamNum = current.Controller.TeamNum;
             }
-            catch
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "ResyncPlayingListsFromEngine: failed reading controller/team for SteamID {SteamId}.", steamId);
                 teamNum = -1;
             }
 

--- a/MixScrims/src/States/Match/VoteKick.cs
+++ b/MixScrims/src/States/Match/VoteKick.cs
@@ -167,7 +167,10 @@ public partial class MixScrims
     internal void HandleVoteKickVote(IPlayer voter, Team team, bool voteYes)
     {
         if (!IsPlayerValid(voter))
+        {
+            logger.LogWarning("HandleVoteKickVote: ignoring vote from invalid/disconnected player {Slot}.", voter?.Slot);
             return;
+        }
 
         bool inProgress = team == Team.CT ? isVoteKickInProgressCt : isVoteKickInProgressT;
         if (!inProgress)

--- a/MixScrims/src/States/PickingTeam/Main.cs
+++ b/MixScrims/src/States/PickingTeam/Main.cs
@@ -95,7 +95,10 @@ public partial class MixScrims
         mixScrimsService.SetMatchState(MatchState.PickingTeam);        
 
         PauseMatch();
-        Core.Engine.ExecuteCommand("exec mixscrims/teampick.cfg");
+        if (Core.Engine is { } pickEngine)
+            pickEngine.ExecuteCommand("exec mixscrims/teampick.cfg");
+        else
+            logger.LogWarning("StartTeamPickingPhase: Core.Engine unavailable; skipping teampick.cfg.");
 
         MovePlayersToDesignatedTeamsPrePick();
 
@@ -123,7 +126,10 @@ public partial class MixScrims
     {
         mixScrimsService.SetMatchState(MatchState.PickingTeam);
 
-        Core.Engine.ExecuteCommand("exec mixscrims/teampick.cfg");
+        if (Core.Engine is { } skipPickEngine)
+            skipPickEngine.ExecuteCommand("exec mixscrims/teampick.cfg");
+        else
+            logger.LogWarning("SkipTeamPickingPhase: Core.Engine unavailable; skipping teampick.cfg.");
         PauseMatch();
 
         var players = GetPlayingPlayers();

--- a/MixScrims/src/States/Surrender/Main.cs
+++ b/MixScrims/src/States/Surrender/Main.cs
@@ -135,6 +135,7 @@ public partial class MixScrims
         PrintMessageToTeam(team, Core.Localizer["announcement.surrender.vote.progress", surrenderVoteYesCount, surrenderVoteNoCount, surrenderTotalEligibleVotes]);
 
         surrenderVoteTimer = Core.Scheduler.DelayBySeconds(cfg.DefaultVoteTimeSeconds, () => SurrenderVoteResult(team));
+        Core.Scheduler.StopOnMapChange(surrenderVoteTimer);
 
         if (cfg.DetailedLogging)
         {
@@ -289,11 +290,12 @@ public partial class MixScrims
         PauseMatch();
 
         // Schedule reset
-        Core.Scheduler.DelayBySeconds(matchResetDelay - 5, () =>
+        var resetToken = Core.Scheduler.DelayBySeconds(matchResetDelay - 5, () =>
         {
             if (cfg.DetailedLogging)
                 logger.LogInformation("Match surrendered by team {Team}, resetting plugin state.", team);
             ResetPluginState();
         });
+        Core.Scheduler.StopOnMapChange(resetToken);
     }
 }

--- a/MixScrims/src/States/Surrender/Main.cs
+++ b/MixScrims/src/States/Surrender/Main.cs
@@ -149,7 +149,10 @@ public partial class MixScrims
     internal void HandleSurrenderVote(IPlayer player, string choice)
     {
         if (!IsPlayerValid(player))
+        {
+            logger.LogWarning("HandleSurrenderVote: ignoring vote from invalid/disconnected player {Slot}.", player?.Slot);
             return;
+        }
 
         if (cfg.DetailedLogging)
         {

--- a/MixScrims/src/States/Timeout/Main.cs
+++ b/MixScrims/src/States/Timeout/Main.cs
@@ -70,7 +70,8 @@ public partial class MixScrims
             PrintMessageToTeam(Team.T, Core.Localizer["command.timeout.remaining_timeouts", timeoutCountT, cfg.Timeouts]);
         }
         BroadcastRemainingTimeoutTime(team);
-        Core.Scheduler.DelayBySeconds(cfg.TimeoutDurationSeconds, EndTimeout);
+        var endTimeoutToken = Core.Scheduler.DelayBySeconds(cfg.TimeoutDurationSeconds, EndTimeout);
+        Core.Scheduler.StopOnMapChange(endTimeoutToken);
     }
 
     /// <summary>
@@ -272,6 +273,7 @@ public partial class MixScrims
         PrintMessageToTeam(team, Core.Localizer["announcement.timeout.vote.progress", timeoutVoteYesCount, timeoutVoteNoCount, timeoutTotalEligibleVotes]);
 
         timeoutVoteTimer = Core.Scheduler.DelayBySeconds(cfg.DefaultVoteTimeSeconds, () => TimeoutVoteResult(team));
+        Core.Scheduler.StopOnMapChange(timeoutVoteTimer);
 
         if (cfg.DetailedLogging)
         {

--- a/MixScrims/src/States/Timeout/Main.cs
+++ b/MixScrims/src/States/Timeout/Main.cs
@@ -287,7 +287,10 @@ public partial class MixScrims
     internal void HandleTimeoutVote(IPlayer player, string choice)
     {
         if (!IsPlayerValid(player))
+        {
+            logger.LogWarning("HandleTimeoutVote: ignoring vote from invalid/disconnected player {Slot}.", player?.Slot);
             return;
+        }
 
         if (cfg.DetailedLogging)
         {

--- a/MixScrims/src/States/Warmup/Main.cs
+++ b/MixScrims/src/States/Warmup/Main.cs
@@ -30,6 +30,8 @@ public partial class MixScrims
         {
             if (Core.Engine is { } engine)
                 engine.ExecuteCommand("exec mixscrims/warmup.cfg");
+            else
+                logger.LogWarning("LoadWarmupConfig: Core.Engine unavailable; skipping warmup.cfg.");
         });
 
         var pluginState = mixScrimsService.GetCurrentPluginState();
@@ -42,6 +44,8 @@ public partial class MixScrims
                 {
                     if (Core.Engine is { } engine)
                         engine.ExecuteCommand("exec mixscrims/staging_overrides.cfg");
+                    else
+                        logger.LogWarning("LoadWarmupConfig: Core.Engine unavailable; skipping staging_overrides.cfg.");
                 });
             });
             Core.Scheduler.StopOnMapChange(token);
@@ -54,6 +58,8 @@ public partial class MixScrims
                 {
                     if (Core.Engine is { } engine)
                         engine.ExecuteCommand("exec mixscrims/production_overrides.cfg");
+                    else
+                        logger.LogWarning("LoadWarmupConfig: Core.Engine unavailable; skipping production_overrides.cfg.");
                 });
             });
             Core.Scheduler.StopOnMapChange(token);

--- a/MixScrims/src/States/Warmup/Main.cs
+++ b/MixScrims/src/States/Warmup/Main.cs
@@ -28,7 +28,8 @@ public partial class MixScrims
 
         Core.Scheduler.NextTick(() =>
         {
-            Core.Engine.ExecuteCommand("exec mixscrims/warmup.cfg");
+            if (Core.Engine is { } engine)
+                engine.ExecuteCommand("exec mixscrims/warmup.cfg");
         });
 
         var pluginState = mixScrimsService.GetCurrentPluginState();
@@ -37,7 +38,11 @@ public partial class MixScrims
         {
             var token = Core.Scheduler.DelayBySeconds(3, () => 
             {
-                Core.Scheduler.NextTick(() => Core.Engine.ExecuteCommand("exec mixscrims/staging_overrides.cfg"));
+                Core.Scheduler.NextTick(() =>
+                {
+                    if (Core.Engine is { } engine)
+                        engine.ExecuteCommand("exec mixscrims/staging_overrides.cfg");
+                });
             });
             Core.Scheduler.StopOnMapChange(token);
         }
@@ -45,7 +50,11 @@ public partial class MixScrims
         {
             var token = Core.Scheduler.DelayBySeconds(3, () => 
             {
-                Core.Scheduler.NextTick(() => Core.Engine.ExecuteCommand("exec mixscrims/production_overrides.cfg"));
+                Core.Scheduler.NextTick(() =>
+                {
+                    if (Core.Engine is { } engine)
+                        engine.ExecuteCommand("exec mixscrims/production_overrides.cfg");
+                });
             });
             Core.Scheduler.StopOnMapChange(token);
         }


### PR DESCRIPTION
## Changes

### Bug Fixes
- Fixed silent failures during map transitions that could cause unobserved async exceptions and server crashes
- Added null guards around `Core.Engine` access in map loading, config execution, and team-limit overrides
- Prevented disposed `IPlayer` references from desyncing playing-team lists during round resync
- Plugin unload now properly unsubscribes lifecycle events and cancels all active timers to prevent callbacks against dead instances

### Improvements
- Replaced silent `catch` blocks and `DetailedLogging`-gated error paths with unconditional warnings so production issues are no longer swallowed
- Invalid/disconnected player votes (timeout, surrender, votekick) now log a warning instead of silently dropping
- Command alias cleanup on hot reload now reports null configuration entries instead of skipping silently